### PR TITLE
Ignore Cake minor and patch updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,5 +6,18 @@
     ],
     "labels": [
         "dependencies"
+    ],
+    "packageRules": [
+        {
+            "description": "Ignore Cake minor and patch updates",
+            "matchManagers": ["nuget"],
+            "matchDepNames": [
+                "Cake.Core",
+                "Cake.Common",
+                "Cake.Testing"
+            ],
+            "matchUpdateTypes": ["minor", "patch"],
+            "enabled": false
+        }
     ]
 }


### PR DESCRIPTION
Ignores minor and patch updates for Cake to follow [best practices](https://cakebuild.net/docs/extending/addins/best-practices#cake-reference)