### PR TITLE
Add configuration preset for Cake Frosting addins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ This repository contains [shared presets] for [Renovate] used in the repositorie
 
 ## Available presets
 
-| Preset                                             | Description                                          |
-|----------------------------------------------------|------------------------------------------------------|
-| `github>cake-contrib/renovate-presets`             | [Default configuration](default.json)                |
-| `github>cake-contrib/renovate-presets:cake-issues` | [Configuration Cake.Issues addins](cake-issues.json) |
+| Preset                                               | Description                                                                  |
+|------------------------------------------------------|------------------------------------------------------------------------------|
+| `github>cake-contrib/renovate-presets`               | [Default configuration](default.json)                                        |
+| `github>cake-contrib/renovate-presets:frosing-addin` | [Additional configuration for addins for Cake Frosting](frosting-addin.json) |
+| `github>cake-contrib/renovate-presets:cake-issues`   | [Configuration Cake.Issues addins](cake-issues.json)                         |
 
 [shared presets]: https://docs.renovatebot.com/config-presets/
 [Renovate]: https://renovatebot.com/

--- a/frosting-addin.json
+++ b/frosting-addin.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "Use Renovate configuration for Cake Frosting addins",
+    "extends": [
+        "github>cake-contrib/renovate-presets"
+    ],
+    "packageRules": [
+        {
+            "description": "Ignore Cake Frosting minor and patch updates",
+            "matchManagers": ["nuget"],
+            "matchDepNames": [
+                "Cake.Frosting"
+            ],
+            "matchUpdateTypes": ["minor", "patch"],
+            "enabled": false
+        }
+    ]
+}


### PR DESCRIPTION
Add configuration preset for Cake Frosting addins, which suppresses minor and patch updates of Cake Frosting. Keeping this in a separate preset to allow use Cake Frosting as runner in default configuration, where for all updates should be considered